### PR TITLE
As per deprecation messages in ChefSpec 4

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -51,7 +51,7 @@ if defined?(ChefSpec)
       end
     end
 
-    def failure_message_for_should
+    def failure_message
       if resource
         if resource.performed_action?('create')
           if unmatched_parameters.empty?
@@ -80,7 +80,7 @@ if defined?(ChefSpec)
       end
     end
 
-    def failure_message_for_should_not
+    def failure_message_when_negated
       if resource
         message = %Q{expected "#{resource.to_s}" actions #{resource.performed_actions.inspect} to not exist}
       else


### PR DESCRIPTION
This updates the ChefSpec matchers to follow along with a deprecation in ChefSpec.

Message is as follows:

> LogrotateAppMatcher implements a legacy RSpec matcher
> protocol. For the current protocol you should expose the failure messages
> via the `failure_message` and `failure_message_when_negated` methods.