### PR TITLE
Don't use commas when using %w

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ node.override['logrotate']['global']['nocompress'] = true
 The same is true of frequency directives; to be certain the frequency directive you want is included in the global configuration, you should override the ones you don't want as false:
 
 ```ruby
-%w[ daily, weekly, yearly ].each do |freq|
+%w[ daily weekly yearly ].each do |freq|
   node.override['logrotate']['global'][freq] = false
 end
 node.override['logrotate']['global']['monthly'] = true

--- a/libraries/logrotate_config.rb
+++ b/libraries/logrotate_config.rb
@@ -21,7 +21,7 @@
 module CookbookLogrotate
   DIRECTIVES = %w(
     compress        copy        copytruncate    daily           dateext
-    delaycompress   ifempty     mailfirst       maillast        missingok
+    delaycompress   hourly      ifempty         mailfirst       maillast        missingok
     monthly         nocompress  nocopy          nocopytruncate  nocreate
     nodelaycompress nodateext   nomail          nomissingok     noolddir
     nosharedscripts noshred     notifempty      sharedscripts   shred


### PR DESCRIPTION
1. "hourly" is a valid directive in logrotate 3.8 and higher.
2. The README provides invalid syntax which fails when run, as the commas are added to the directive:

<pre>Relevant File Content:
  ----------------------
  /var/chef/cache/cookbooks/logrotate/libraries/logrotate_config.rb:

   45:
   46:      class << self
   47:        def from_hash(hash)
   48:          new(hash)
   49:        end
   50:
   51:        def directives_from(hash)
   52>>         hash.select { |k, v| DIRECTIVES.include?(k) && v }.keys
   53:        end
   54:
   55:        def values_from(hash)
   56:          hash.select { |k| VALUES.include?(k) }
   57:        end
   58:
   59:        def paths_from(hash)
   60:          hash.select { |k| !(DIRECTIVES_AND_VALUES.include?(k)) }.reduce({}) do | accum_paths, (path, config) |
   61:            accum_paths[path] = {
</pre>