### PR TITLE
WIP: Add support for the AIX platform.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ Berksfile.lock
 bin/
 tmp/
 vendor/
+Berksfile.lock
 
 # RVM
 .ruby-version

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,12 +1,20 @@
-driver_plugin: vagrant
-driver_config:
-  require_chef_omnibus: true
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_zero
 
 platforms:
+  - name: ubuntu-14.04
+    run_list:
+      - recipe[ubuntu::default]
   - name: ubuntu-12.04
     run_list:
-      - recipe[fake::prep]
-  - name: centos-6.5
+      - recipe[ubuntu::default]
+  - name: centos-7.2
+  - name: centos-6.6
+  - name: centos-5.11
 
 suites:
   - name: default

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
+---
+language: ruby
+cache: bundler
+sudo: false
+script: bundle exec rake travis
 rvm:
-  - 2.0.0
-script:
-  - bundle exec foodcritic -f any . --tags ~FC015
-  - bundle exec rspec --color --format progress
-  - bundle exec rubocop -l
+  - 2.2
+branches:
+  only:
+    - master
+matrix:
+  fast_finish: true

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,7 @@
+source 'https://supermarket.chef.io'
+metadata
+
+group :test, :integration do
+  cookbook 'fake', './test/fixtures/cookbooks/fake'
+  cookbook 'ubuntu'
+end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ logrotate Cookbook CHANGELOG
 This file is used to list changes made in each version of the
 logrotate cookbook.
 
+v1.10
+-----
+## Improvements
+- Add support for AIX platform.
+- Update the testing harness to latest Test Kitchen.
+- Update the Travis configuration.
+
 v1.9.2
 ------
 

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,8 @@ APPENDIX: How to apply the Apache License to your work.
    same "printed page" as the copyright notice for easier
    identification within third-party archives.
 
-Copyright [yyyy] [name of copyright owner]
+Copyright 2009-2013, Chef Software, Inc.
+Copyright 2016, Bloomberg Finance L.P.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,39 @@
+#!/usr/bin/env rake
+
+require 'bundler/setup'
+require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
+require 'foodcritic'
+require 'kitchen'
+
+namespace :style do
+  desc 'Run Ruby style checks'
+  RuboCop::RakeTask.new(:ruby)
+
+  desc 'Run Chef style checks'
+  FoodCritic::Rake::LintTask.new(:chef)
+end
+
+desc 'Run all style checks'
+task style: ['style:chef', 'style:ruby']
+
+desc 'Run ChefSpec unit tests'
+RSpec::Core::RakeTask.new(:unit) do |t|
+  t.pattern = 'test/spec/**{,/*/**}/*_spec.rb'
+end
+
+# Integration tests. Kitchen.ci
+desc 'Run Test Kitchen with Vagrant'
+task :vagrant do
+  Kitchen.logger = Kitchen.default_file_logger
+  Kitchen::Config.new.instances.each do |instance|
+    instance.test(:always)
+  end
+end
+
+desc 'Run style & unit tests on Travis'
+task travis: %w(style unit)
+
+# Default
+desc 'Run style, unit, and Vagrant-based integration tests'
+task default: %w(style unit vagrant)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,6 +3,7 @@
 # Attribute:: default
 #
 # Copyright 2013, Chef
+# Copyright 2016, Bloomberg Finance L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +17,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+default['logrotate']['package'] = {
+  'name' => 'logrotate',
+  'source' => nil,
+  'version' => nil,
+  'provider' => nil
+}
+
+default['logrotate']['directory'] = '/etc/logrotate.d'
+
+default['logrotate']['cron']['name'] = 'logrotate'
+default['logrotate']['cron']['command'] = '/usr/sbin/logrotate /etc/logrotate.conf'
+default['logrotate']['cron']['minute'] = 35
+default['logrotate']['cron']['hour'] = 2
 
 default['logrotate']['global'] = {
   'weekly' => true,

--- a/cookbooks
+++ b/cookbooks
@@ -1,1 +1,0 @@
-test/fixtures/cookbooks

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,11 +4,11 @@ maintainer_email  'steve@chef.io'
 license           'Apache 2.0'
 description       'Installs logrotate package and provides a definition for logrotate configs'
 long_description  'Installs the logrotate package, manages /etc/logrotate.conf, and provides a logrotate_app definition.'
-version           '1.9.2'
+version           '1.10.0'
 
 recipe 'logrotate', 'Installs logrotate package'
 provides 'logrotate_app'
 
-%w{amazon centos debian fedora redhat scientific solaris2 ubuntu}.each do |platform|
+%w{aix amazon centos debian fedora redhat scientific solaris2 ubuntu}.each do |platform|
   supports platform
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -3,6 +3,7 @@
 # Recipe:: default
 #
 # Copyright 2009-2013, Chef Software, Inc.
+# Copyright 2016, Bloomberg Finance L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,20 +17,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+return if platform?('windows')
 
-package 'logrotate'
-
-directory "/etc/logrotate.d" do
-  owner "root"
-  group "root"
-  mode "0755"
-  action :create
+package node['logrotate']['package']['name'] do
+  provider node['logrotate']['package']['provider'] if node['logrotate']['package']['provider']
+  source node['logrotate']['package']['provider'] if node['logrotate']['package']['source']
+  version node['logrotate']['package']['provider'] if node['logrotate']['package']['version']
+  action :upgrade
 end
 
-if platform? "solaris2" # ~FC023 style preference
-  cron "logrotate" do
-    minute "35"
-    hour "7"
-    command "/usr/sbin/logrotate /etc/logrotate.conf"
-  end
+directory node['logrotate']['directory'] do
+  owner 'root'
+  group node['root_group']
+  mode '0755'
+end
+
+cron node['logrotate']['cron']['name'] do
+  minute node['logrotate']['cron']['minute']
+  hour node['logrotate']['cron']['hour']
+  command node['logrotate']['cron']['command']
+  not_if { platform_family?('debian') }
+  not_if { platform_family?('rhel') }
 end

--- a/test/fixtures/cookbooks/fake/recipes/prep.rb
+++ b/test/fixtures/cookbooks/fake/recipes/prep.rb
@@ -1,5 +1,0 @@
-execute 'apt-get-update' do
-  command 'apt-get update; touch /var/lib/apt/periodic/update-success-stamp'
-  ignore_failure true
-  not_if { ::File.exist?('/var/lib/apt/periodic/update-success-stamp') }
-end


### PR DESCRIPTION
This commit adds the support necessary for platforms that do not already
have the logrotate package (or may need to install the package from
source). Additionally, all attributes can be driven from an external
Policyfile or cookbook.

/cc @acaiafa