### PR TITLE
Do not call default recipe in logrotate_app definition

### DIFF
--- a/definitions/logrotate_app.rb
+++ b/definitions/logrotate_app.rb
@@ -37,10 +37,10 @@ define(:logrotate_app, log_rotate_params) do
   options = options_tmp.respond_to?(:each) ? options_tmp : options_tmp.split
   options << 'sharedscripts' if params[:sharedscripts]
 
-  directory "/etc/logrotate.d" do
-    owner "root"
-    group "root"
-    mode "0755"
+  directory '/etc/logrotate.d' do
+    owner 'root'
+    group 'root'
+    mode '0755'
     action :create
   end
 

--- a/definitions/logrotate_app.rb
+++ b/definitions/logrotate_app.rb
@@ -33,7 +33,7 @@ log_rotate_params = {
 }
 
 define(:logrotate_app, log_rotate_params) do
-  include_recipe 'logrotate::default'
+  #include_recipe 'logrotate::default'
 
   options_tmp = params[:options] ||= %w(missingok compress delaycompress copytruncate notifempty)
   options = options_tmp.respond_to?(:each) ? options_tmp : options_tmp.split

--- a/definitions/logrotate_app.rb
+++ b/definitions/logrotate_app.rb
@@ -33,11 +33,16 @@ log_rotate_params = {
 }
 
 define(:logrotate_app, log_rotate_params) do
-  #include_recipe 'logrotate::default'
-
   options_tmp = params[:options] ||= %w(missingok compress delaycompress copytruncate notifempty)
   options = options_tmp.respond_to?(:each) ? options_tmp : options_tmp.split
   options << 'sharedscripts' if params[:sharedscripts]
+
+  directory "/etc/logrotate.d" do
+    owner "root"
+    group "root"
+    mode "0755"
+    action :create
+  end
 
   if params[:enable]
     invalid_options = options - CookbookLogrotate::DIRECTIVES

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'steve@chef.io'
 license           'Apache 2.0'
 description       'Installs logrotate package and provides a definition for logrotate configs'
 long_description  'Installs the logrotate package, manages /etc/logrotate.conf, and provides a logrotate_app definition.'
-version           '1.9.2'
+version           '1.10.0'
 
 recipe 'logrotate', 'Installs logrotate package'
 provides 'logrotate_app'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,17 +19,16 @@
 
 package 'logrotate'
 
-directory "/etc/logrotate.d" do
-  owner "root"
-  group "root"
-  mode "0755"
+directory '/etc/logrotate.d' do
+  owner 'root'
+  group 'root'
+  mode '0755'
   action :create
 end
 
-if platform? "solaris2" # ~FC023 style preference
-  cron "logrotate" do
-    minute "35"
-    hour "7"
-    command "/usr/sbin/logrotate /etc/logrotate.conf"
-  end
+cron 'logrotate' do
+  minute '35'
+  hour '7'
+  command '/usr/sbin/logrotate /etc/logrotate.conf'
+  only_if { platform? 'solaris2' }
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -1,9 +1,33 @@
 require 'spec_helper'
 
 describe 'logrotate::default' do
-  let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
+  context 'When all attributes are default, on an unspecified platform' do
+    let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
 
-  it 'installs the logrotate package' do
-    expect(chef_run).to install_package('logrotate')
+    it 'installs the logrotate package' do
+      expect(chef_run).to install_package('logrotate')
+    end
+
+    it 'shoudl create the logrotate.d directory' do
+      expect(chef_run).to create_directory('/etc/logrotate.d')
+    end
+
+    it 'shoudl not create a cron entry' do
+      expect(chef_run).not_to create_cron('logrotate')
+    end
+  end
+
+  context 'When all attributes are default, on solaris2' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'solaris2', version: 5.11).converge(described_recipe)
+    end
+
+    it 'shoudl create a cron entry' do
+      expect(chef_run).to create_cron('logrotate').with(
+        minute: '35',
+        hour: '7',
+        command: '/usr/sbin/logrotate /etc/logrotate.conf'
+      )
+    end
   end
 end


### PR DESCRIPTION
This change is important in our use case, but it may cause some
problems to existing users of the cookbook. The problem of calling
logrotate::default inside the logrotate_app definition is that if
you can't reach the rpm repotitory in that moment you can't configure
the logrotate. We are baking our AMIs and deploying them in a VPC
without access to any repository, some configurations should be applied
inside the VPC but we can not configure any repository or install
any package in that moment.