### PR TITLE
Control package action via attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,6 +24,7 @@ default["logrotate"]["package"] = {
   "source" => nil,
   "version" => nil,
   "provider" => nil,
+  "action" => :upgrade,
 }
 
 default["logrotate"]["directory"] = "/etc/logrotate.d"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,7 +24,7 @@ package node["logrotate"]["package"]["name"] do
   provider node["logrotate"]["package"]["provider"] if node["logrotate"]["package"]["provider"]
   source node["logrotate"]["package"]["source"] if node["logrotate"]["package"]["source"]
   version node["logrotate"]["package"]["version"] if node["logrotate"]["package"]["version"]
-  action :upgrade
+  action node["logrotate"]["package"]["action"]
 end
 
 directory node["logrotate"]["directory"] do


### PR DESCRIPTION
Upgrade action does not allow precise control of the installed version
This commit introduce a new attribute allowing to change the action
performed by the package.

*Cc:* @aboten