### PR TITLE
Add support for global scripts

### DIFF
--- a/libraries/logrotate_config.rb
+++ b/libraries/logrotate_config.rb
@@ -32,11 +32,11 @@ module CookbookLogrotate
 
   SCRIPTS = %w{firstaction prerotate postrotate lastaction preremove} unless const_defined?(:SCRIPTS)
 
-  DIRECTIVES_AND_VALUES = DIRECTIVES + VALUES unless const_defined?(:DIRECTIVES_AND_VALUES)
+  DIRECTIVES_AND_VALUES_AND_SCRIPTS = DIRECTIVES + VALUES + SCRIPTS unless const_defined?(:DIRECTIVES_AND_VALUES_AND_SCRIPTS)
 
   # Helper class for creating configurations
   class LogrotateConfiguration
-    attr_reader :directives, :values, :paths
+    attr_reader :directives, :values, :scripts, :paths
 
     class << self
       def from_hash(hash)
@@ -52,7 +52,7 @@ module CookbookLogrotate
       end
 
       def paths_from(hash)
-        hash.select { |k| !(DIRECTIVES_AND_VALUES.include?(k)) }.reduce({}) do |accum_paths, (path, config)|
+        hash.select { |k| !(DIRECTIVES_AND_VALUES_AND_SCRIPTS.include?(k)) }.reduce({}) do |accum_paths, (path, config)|
           accum_paths[path] = {
             "directives" => directives_from(config),
             "values" => values_from(config),
@@ -82,6 +82,7 @@ module CookbookLogrotate
     def initialize(hash)
       @directives = LogrotateConfiguration.directives_from(hash)
       @values = LogrotateConfiguration.values_from(hash)
+      @scripts = LogrotateConfiguration.scripts_from(hash)
       @paths = LogrotateConfiguration.paths_from(hash)
     end
   end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "steve@chef.io"
 license           "Apache 2.0"
 description       "Installs logrotate package and provides a definition for logrotate configs"
 long_description  "Installs the logrotate package, manages /etc/logrotate.conf, and provides a logrotate_app definition."
-version           "2.1.0"
+version           "2.1.1"
 
 source_url "https://github.com/stevendanna/logrotate" if respond_to?(:source_url)
 issues_url "https://github.com/stevendanna/logrotate/issues" if respond_to?(:issues_url)

--- a/spec/unit/recipes/global_spec.rb
+++ b/spec/unit/recipes/global_spec.rb
@@ -13,4 +13,24 @@ describe "logrotate::global" do
     expect(template.source).to eq("logrotate-global.erb")
     expect(template.mode).to eq("0644")
   end
+
+  shared_examples "script in global context" do
+    it "puts the script in the configuration file" do
+      expect(chef_run).to render_file("/etc/logrotate.conf").with_content(content_regexp)
+    end
+  end
+
+  %w{postrotate prerotate firstaction lastaction}.each do |script_type|
+    context "when a #{script_type} script is present in the global attribute" do
+      let(:script) { "/usr/bin/test_#{script_type}_script" }
+      let(:chef_run) do
+        ChefSpec::SoloRunner.new do |node|
+          node.override["logrotate"]["global"][script_type] = script
+        end.converge(described_recipe)
+      end
+      let(:content_regexp) { /#{script_type}\n#{script}\nendscript/ }
+
+      it_behaves_like "script in global context"
+    end
+  end
 end

--- a/templates/default/logrotate-global.erb
+++ b/templates/default/logrotate-global.erb
@@ -9,6 +9,12 @@
 <%= k %> <%= v %>
 <% end -%>
 
+<% @configuration.scripts.each do | scripttype, body | -%>
+<%= scripttype %>
+<%= body %>
+endscript
+<% end -%>
+
 include /etc/logrotate.d
 
 <% @configuration.paths.each do |path, path_config| -%>


### PR DESCRIPTION
What does this change do?
It allows scripts in the global context.

Why is this change needed?
Logrotate allows using scripts in global context
and they can be useful, but this cookbook did not
support this option.