### PR TITLE
Add su directive to list of available directives

### DIFF
--- a/libraries/logrotate_config.rb
+++ b/libraries/logrotate_config.rb
@@ -23,7 +23,7 @@ module CookbookLogrotate
                   dateyesterday delaycompress hourly ifempty mailfirst maillast
                   missingok monthly nocompress nocopy nocopytruncate nocreate nocreateolddir
                   nodelaycompress nodateext nomail nomissingok noolddir
-                  nosharedscripts noshred notifempty renamecopy sharedscripts shred weekly
+                  nosharedscripts noshred notifempty renamecopy sharedscripts shred su weekly
                   yearly).freeze unless const_defined?(:DIRECTIVES)
 
   VALUES = %w(compresscmd uncompresscmd compressext compressoptions


### PR DESCRIPTION
Adding the su directive will prevent error messages such as:

`skipping "/var/log/syslog" because parent directory has insecure permissions`

In the config you're able to specify `su 'user group'` now which will be written to the /etc/logrotate.d/filename. Previously I did not see a way to implement this with the existing directives.